### PR TITLE
Switch tokenId to be uint256

### DIFF
--- a/src/PBTSimple.sol
+++ b/src/PBTSimple.sol
@@ -21,7 +21,7 @@ contract PBTSimple is ERC721ReadOnly, IPBT {
     using ECDSA for bytes32;
 
     struct TokenData {
-        uint128 tokenId;
+        uint256 tokenId;
         address chipAddress;
         bool set;
     }
@@ -36,13 +36,13 @@ contract PBTSimple is ERC721ReadOnly, IPBT {
     // Should only be called for tokenIds that have not yet been minted
     // If the tokenId has already been minted, use _updateChips instead
     // TODO: consider preventing multiple chip addresses mapping to the same tokenId (store a tokenId->chip mapping)
-    function _seedChipToTokenMapping(address[] memory chipAddresses, uint128[] memory tokenIds) internal {
+    function _seedChipToTokenMapping(address[] memory chipAddresses, uint256[] memory tokenIds) internal {
         _seedChipToTokenMapping(chipAddresses, tokenIds, true);
     }
 
     function _seedChipToTokenMapping(
         address[] memory chipAddresses,
-        uint128[] memory tokenIds,
+        uint256[] memory tokenIds,
         bool throwIfTokenAlreadyMinted
     ) internal {
         if (tokenIds.length != chipAddresses.length) {
@@ -50,7 +50,7 @@ contract PBTSimple is ERC721ReadOnly, IPBT {
         }
         for (uint256 i = 0; i < tokenIds.length; ++i) {
             address chipAddress = chipAddresses[i];
-            uint128 tokenId = tokenIds[i];
+            uint256 tokenId = tokenIds[i];
             if (throwIfTokenAlreadyMinted && _exists(tokenId)) {
                 revert SeedingChipDataForExistingToken();
             }
@@ -72,7 +72,7 @@ contract PBTSimple is ERC721ReadOnly, IPBT {
                 revert UpdatingChipForUnsetChipMapping();
             }
             address newChipAddress = chipAddressesNew[i];
-            uint128 tokenId = oldTokenData.tokenId;
+            uint256 tokenId = oldTokenData.tokenId;
             _tokenDatas[newChipAddress] = TokenData(tokenId, newChipAddress, true);
             if (_exists(tokenId)) {
                 emit PBTChipRemapping(tokenId, oldChipAddress, newChipAddress);
@@ -122,7 +122,7 @@ contract PBTSimple is ERC721ReadOnly, IPBT {
         returns (uint256)
     {
         TokenData memory tokenData = _getTokenDataForChipSignature(signatureFromChip, blockNumberUsedInSig);
-        uint128 tokenId = tokenData.tokenId;
+        uint256 tokenId = tokenData.tokenId;
         _mint(_msgSender(), tokenId);
         emit PBTMint(tokenId, tokenData.chipAddress);
         return tokenId;
@@ -145,7 +145,7 @@ contract PBTSimple is ERC721ReadOnly, IPBT {
         uint256 blockNumberUsedInSig,
         bool useSafeTransferFrom
     ) internal virtual {
-        uint128 tokenId = _getTokenDataForChipSignature(signatureFromChip, blockNumberUsedInSig).tokenId;
+        uint256 tokenId = _getTokenDataForChipSignature(signatureFromChip, blockNumberUsedInSig).tokenId;
         if (useSafeTransferFrom) {
             _safeTransfer(ownerOf(tokenId), _msgSender(), tokenId, "");
         } else {

--- a/src/mocks/PBTSimpleMock.sol
+++ b/src/mocks/PBTSimpleMock.sol
@@ -12,7 +12,7 @@ contract PBTSimpleMock is PBTSimple {
 
     function seedChipToTokenMapping(
         address[] memory chipAddresses,
-        uint128[] memory tokenIds,
+        uint256[] memory tokenIds,
         bool throwIfTokenAlreadyMinted
     ) public {
         _seedChipToTokenMapping(chipAddresses, tokenIds, throwIfTokenAlreadyMinted);

--- a/test/PBTSimpleTest.sol
+++ b/test/PBTSimpleTest.sol
@@ -9,9 +9,9 @@ contract PBTSimpleTest is Test {
     event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
 
     PBTSimpleMock public pbt;
-    uint128 public tokenId1 = 1;
-    uint128 public tokenId2 = 2;
-    uint128 public tokenId3 = 3;
+    uint256 public tokenId1 = 1;
+    uint256 public tokenId2 = 2;
+    uint256 public tokenId3 = 3;
     address public user1 = vm.addr(1);
     address public user2 = vm.addr(2);
     address public user3 = vm.addr(3);
@@ -35,7 +35,7 @@ contract PBTSimpleTest is Test {
         chipAddresses[0] = chipAddr1;
         chipAddresses[1] = chipAddr2;
 
-        uint128[] memory tokenIds = new uint128[](1);
+        uint256[] memory tokenIds = new uint256[](1);
         tokenIds[0] = tokenId1;
 
         vm.expectRevert(ArrayLengthMismatch.selector);
@@ -47,7 +47,7 @@ contract PBTSimpleTest is Test {
         chipAddresses[0] = chipAddr1;
         chipAddresses[1] = chipAddr2;
 
-        uint128[] memory tokenIds = new uint128[](2);
+        uint256[] memory tokenIds = new uint256[](2);
         tokenIds[0] = tokenId1;
         tokenIds[1] = tokenId2;
 
@@ -63,7 +63,7 @@ contract PBTSimpleTest is Test {
         chipAddresses[0] = chipAddr1;
         chipAddresses[1] = chipAddr2;
 
-        uint128[] memory tokenIds = new uint128[](2);
+        uint256[] memory tokenIds = new uint256[](2);
         tokenIds[0] = tokenId1;
         tokenIds[1] = tokenId2;
 
@@ -111,7 +111,7 @@ contract PBTSimpleTest is Test {
         chipAddresses[0] = chipAddr1;
         chipAddresses[1] = chipAddr2;
 
-        uint128[] memory tokenIds = new uint128[](2);
+        uint256[] memory tokenIds = new uint256[](2);
         tokenIds[0] = tokenId1;
         tokenIds[1] = tokenId2;
 
@@ -160,7 +160,7 @@ contract PBTSimpleTest is Test {
         // Set chipAddr3 to tokenDatas
         address[] memory chipAddresses = new address[](1);
         chipAddresses[0] = chipAddr3;
-        uint128[] memory tokenIds = new uint128[](1);
+        uint256[] memory tokenIds = new uint256[](1);
         tokenIds[0] = tokenId3;
         pbt.seedChipToTokenMapping(chipAddresses, tokenIds, true);
 
@@ -181,7 +181,7 @@ contract PBTSimpleTest is Test {
         // Set chipAddr3 to tokenDatas
         address[] memory chipAddresses = new address[](1);
         chipAddresses[0] = chipAddr3;
-        uint128[] memory tokenIds = new uint128[](1);
+        uint256[] memory tokenIds = new uint256[](1);
         tokenIds[0] = tokenId3;
         pbt.seedChipToTokenMapping(chipAddresses, tokenIds, true);
 


### PR DESCRIPTION
To be consistent with tokenIds in other NFT implementations, we're switching this to uint256 since it doesn't take up more storage.