### PR TITLE
feat: update ERC721ReadOnly to work with OZ v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chiru-labs/pbt",
-  "version": "0.5.0",
+  "version": "0.4.1",
   "description": "Contracts for Physical Backed Tokens (ERC-5791). ",
   "files": [
     "/src/**/*.sol"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chiru-labs/pbt",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Contracts for Physical Backed Tokens (ERC-5791). ",
   "files": [
     "/src/**/*.sol"

--- a/src/v1/ERC721ReadOnly.sol
+++ b/src/v1/ERC721ReadOnly.sol
@@ -14,7 +14,7 @@ contract ERC721ReadOnly is ERC721 {
     }
 
     function getApproved(uint256 tokenId) public view virtual override returns (address) {
-        require(_exists(tokenId), "ERC721: invalid token ID");
+        require(_ownerOf(tokenId) != address(0), "ERC721: invalid token ID");
         return address(0);
     }
 
@@ -28,10 +28,6 @@ contract ERC721ReadOnly is ERC721 {
 
     function transferFrom(address, address, uint256) public virtual override {
         revert("ERC721 public transferFrom not allowed");
-    }
-
-    function safeTransferFrom(address, address, uint256) public virtual override {
-        revert("ERC721 public safeTransferFrom not allowed");
     }
 
     function safeTransferFrom(address, address, uint256, bytes memory) public virtual override {

--- a/src/v1/PBTRandom.sol
+++ b/src/v1/PBTRandom.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import "./IPBT.sol";
 import "./ERC721ReadOnly.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 error InvalidSignature();
 error InvalidChipAddress();
@@ -20,6 +21,7 @@ error BlockNumberTooOld();
  */
 contract PBTRandom is ERC721ReadOnly, IPBT {
     using ECDSA for bytes32;
+    using MessageHashUtils for bytes32;  
 
     struct TokenData {
         uint256 tokenId;
@@ -86,7 +88,7 @@ contract PBTRandom is ERC721ReadOnly, IPBT {
         override
         returns (bool)
     {
-        if (!_exists(tokenId)) {
+        if (_ownerOf(tokenId) == address(0)) {
             revert NoMintedTokenForChip();
         }
         bytes32 signedHash = keccak256(payload).toEthSignedMessageHash();

--- a/src/v1/PBTSimple.sol
+++ b/src/v1/PBTSimple.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.13;
 import "./IPBT.sol";
 import "./ERC721ReadOnly.sol";
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 
 error InvalidSignature();
 error NoMintedTokenForChip();
@@ -19,6 +20,7 @@ error BlockNumberTooOld();
  */
 contract PBTSimple is ERC721ReadOnly, IPBT {
     using ECDSA for bytes32;
+    using MessageHashUtils for bytes32;  
 
     struct TokenData {
         uint256 tokenId;
@@ -54,7 +56,7 @@ contract PBTSimple is ERC721ReadOnly, IPBT {
         for (uint256 i = 0; i < tokenIdsLength; ++i) {
             address chipAddress = chipAddresses[i];
             uint256 tokenId = tokenIds[i];
-            if (throwIfTokenAlreadyMinted && _exists(tokenId)) {
+            if (throwIfTokenAlreadyMinted && _ownerOf(tokenId) != address(0)) {
                 revert SeedingChipDataForExistingToken();
             }
             _tokenDatas[chipAddress] = TokenData(tokenId, chipAddress, true);
@@ -80,7 +82,7 @@ contract PBTSimple is ERC721ReadOnly, IPBT {
             address newChipAddress = chipAddressesNew[i];
             uint256 tokenId = oldTokenData.tokenId;
             _tokenDatas[newChipAddress] = TokenData(tokenId, newChipAddress, true);
-            if (_exists(tokenId)) {
+            if (_ownerOf(tokenId) != address(0)) {
                 emit PBTChipRemapping(tokenId, oldChipAddress, newChipAddress);
             }
             delete _tokenDatas[oldChipAddress];
@@ -89,7 +91,7 @@ contract PBTSimple is ERC721ReadOnly, IPBT {
 
     function tokenIdFor(address chipAddress) external view override returns (uint256) {
         uint256 tokenId = tokenIdMappedFor(chipAddress);
-        if (!_exists(tokenId)) {
+        if (_ownerOf(tokenId) == address(0)) {
             revert NoMintedTokenForChip();
         }
         return tokenId;
@@ -109,7 +111,7 @@ contract PBTSimple is ERC721ReadOnly, IPBT {
         override
         returns (bool)
     {
-        if (!_exists(tokenId)) {
+        if (_ownerOf(tokenId) == address(0)) {
             revert NoMintedTokenForChip();
         }
         bytes32 signedHash = keccak256(payload).toEthSignedMessageHash();

--- a/src/v2/ERC721ReadOnly.sol
+++ b/src/v2/ERC721ReadOnly.sol
@@ -14,7 +14,7 @@ contract ERC721ReadOnly is ERC721 {
     }
 
     function getApproved(uint256 tokenId) public view virtual override returns (address) {
-        require(_exists(tokenId), "ERC721: invalid token ID");
+        require(_ownerOf(tokenId) != address(0), "ERC721: invalid token ID");
         return address(0);
     }
 
@@ -27,14 +27,10 @@ contract ERC721ReadOnly is ERC721 {
     }
 
     function transferFrom(address, address, uint256) public virtual override {
-        revert("ERC721 public transferFrom not allowed");
-    }
-
-    function safeTransferFrom(address, address, uint256) public virtual override {
-        revert("ERC721 public safeTransferFrom not allowed");
+        revert("Use transferToken() instead of transferFrom()");
     }
 
     function safeTransferFrom(address, address, uint256, bytes memory) public virtual override {
-        revert("ERC721 public safeTransferFrom not allowed");
+        revert("Use transferToken() instead of safeTransferFrom()");
     }
 }


### PR DESCRIPTION
Latest version of ERC721.sol from OpenZeppelin does not have an `_exists()` function anymore and the `safeTransferFrom` with three vars is not virtual. 

In addition, keccak256().toEthSignedMessageHash() is longer packaged into EDCSA and requires importing an additional helper `MessageHashUtils.sol`

This PR updates the following files to be compatible with OZ v5.0+ 

- v2
  - ERC721ReadOnly.sol 
- v1
  - ERC721ReadOnly.sol 
  - PBTRandom.sol
  - PBTSimple.sol

It also updates the openzeppelin submodule to latest version.
